### PR TITLE
Add 16‑bit output option

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ It was born out of a need from an astrophotography Discord community called the 
 - GUI built with **Tkinter**, fully translatable (EN/FR)
 - Flexible FITS export with configurable `axis_order` (default `HWC`) and
   proper `BSCALE`/`BZERO` for float images
+- Option to save the final mosaic as 16-bit integer FITS
 
 ---
 

--- a/locales/en.json
+++ b/locales/en.json
@@ -4,6 +4,7 @@
     "folders_frame_title": "Folders",
     "input_folder_label": "Input Folder (Raws):",
     "output_folder_label": "Output Folder:",
+    "save_final_16bit_label": "Save Final Mosaic as 16-bit:",
     "astap_config_frame_title": "ASTAP Configuration",
     "astap_exe_label": "ASTAP Executable Path:",
     "astap_data_dir_label": "ASTAP Data Directory (G17/H17):",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -4,6 +4,7 @@
     "folders_frame_title": "Dossiers",
     "input_folder_label": "Dossier d'Entrée (Brutes) :",
     "output_folder_label": "Dossier de Sortie :",
+    "save_final_16bit_label": "Sauvegarder la mosaïque finale en 16 bits :",
     "astap_config_frame_title": "Configuration ASTAP",
     "astap_exe_label": "Chemin Exécutable ASTAP :",
     "astap_data_dir_label": "Dossier Données ASTAP (G17/H17) :",

--- a/zemosaic_config.json
+++ b/zemosaic_config.json
@@ -16,5 +16,6 @@
     "apply_radial_weight": false,
     "radial_feather_fraction": 0.8,
     "radial_shape_power": 2.0,
-    "final_assembly_method": "reproject_coadd"
+    "final_assembly_method": "reproject_coadd",
+    "save_final_as_uint16": false
 }

--- a/zemosaic_config.py
+++ b/zemosaic_config.py
@@ -24,6 +24,7 @@ DEFAULT_CONFIG = {
     "radial_feather_fraction": 0.8,
     "radial_shape_power": 2.0,
     "final_assembly_method": "reproject_coadd", # Options: "reproject_coadd", "incremental",
+    "save_final_as_uint16": False,
     # --- CLES POUR LE ROGNAGE DES MASTER TUILES ---
     "apply_master_tile_crop": True,       # Désactivé par défaut
     "master_tile_crop_percent": 18.0      # Pourcentage par côté si activé (ex: 10%)

--- a/zemosaic_gui.py
+++ b/zemosaic_gui.py
@@ -130,6 +130,7 @@ class ZeMosaicGUI:
         self.astap_downsample_var = tk.IntVar(value=self.config.get("astap_default_downsample", 2))
         self.astap_sensitivity_var = tk.IntVar(value=self.config.get("astap_default_sensitivity", 100))
         self.cluster_threshold_var = tk.DoubleVar(value=self.config.get("cluster_panel_threshold", 0.5))
+        self.save_final_uint16_var = tk.BooleanVar(value=self.config.get("save_final_as_uint16", False))
         
         self.is_processing = False
         self.processing_thread = None
@@ -374,6 +375,9 @@ class ZeMosaicGUI:
         ttk.Label(folders_frame, text="").grid(row=1, column=0, padx=5, pady=5, sticky="w"); self.translatable_widgets["output_folder_label"] = folders_frame.grid_slaves(row=1,column=0)[0]
         ttk.Entry(folders_frame, textvariable=self.output_dir_var, width=60).grid(row=1, column=1, padx=5, pady=5, sticky="ew")
         ttk.Button(folders_frame, text="", command=self._browse_output_dir).grid(row=1, column=2, padx=5, pady=5); self.translatable_widgets["browse_button_output"] = folders_frame.grid_slaves(row=1,column=2)[0]
+
+        ttk.Label(folders_frame, text="").grid(row=2, column=0, padx=5, pady=5, sticky="w"); self.translatable_widgets["save_final_16bit_label"] = folders_frame.grid_slaves(row=2,column=0)[0]
+        ttk.Checkbutton(folders_frame, variable=self.save_final_uint16_var).grid(row=2, column=1, padx=5, pady=5, sticky="w")
 
 
         # --- ASTAP Configuration Frame ---
@@ -1098,7 +1102,8 @@ class ZeMosaicGUI:
             num_base_workers_gui_val,
             # --- NOUVEAUX ARGUMENTS POUR LE ROGNAGE ---
             apply_master_tile_crop_val,
-            master_tile_crop_percent_val
+            master_tile_crop_percent_val,
+            self.save_final_uint16_var.get()
             # --- FIN NOUVEAUX ARGUMENTS ---
         )
         

--- a/zemosaic_worker.py
+++ b/zemosaic_worker.py
@@ -1111,8 +1111,9 @@ def run_hierarchical_mosaic(
     num_base_workers_config: int,
         # --- ARGUMENTS POUR LE ROGNAGE ---
     apply_master_tile_crop_config: bool,
-    master_tile_crop_percent_config: float
-    
+    master_tile_crop_percent_config: float,
+    save_final_as_uint16_config: bool
+
 ):
     """
     Orchestre le traitement de la mosaïque hiérarchique.
@@ -1540,7 +1541,7 @@ def run_hierarchical_mosaic(
             output_path=final_fits_path,
             header=final_header,
             overwrite=True,
-            save_as_float=True,
+            save_as_float=not save_final_as_uint16_config,
             progress_callback=progress_callback,
             axis_order="HWC",
         )


### PR DESCRIPTION
## Summary
- add `save_final_as_uint16` setting and GUI checkbox near folders
- include translations for the new option
- document 16‑bit export in README

## Testing
- `python -m py_compile zemosaic_config.py zemosaic_gui.py zemosaic_worker.py`
- `python test.py` *(fails: reproject, psutil missing)*

------
https://chatgpt.com/codex/tasks/task_e_683f5c628054832f90c1cd58814ac6cb