### PR TITLE
Fix f-string backslash issue in run_zemosaic

### DIFF
--- a/run_zemosaic.py
+++ b/run_zemosaic.py
@@ -50,7 +50,7 @@ except ImportError as e:
     ZeMosaicGUI = None
 
 print("--- run_zemosaic.py: FIN DES IMPORTS ---")
-print(f"DEBUG (run_zemosaic): sys.path complet: \n{'\n'.join(sys.path)}")
+print("DEBUG (run_zemosaic): sys.path complet:\n" + "\n".join(sys.path))
 print("-" * 50)
 
 


### PR DESCRIPTION
## Summary
- fix SyntaxError on Windows by removing a backslash from an f-string expression

## Testing
- `python -m py_compile run_zemosaic.py`

------
https://chatgpt.com/codex/tasks/task_e_6842c5f1e270832fabdc971f60308494