### PR TITLE
Fix broken localization JSON

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -288,7 +288,7 @@
     "num_workers_label": "Processing Threads:",
     "num_workers_note": "(0 = auto, based on CPU cores)",
     "stacking_min_radial_floor_label": "Min Radial Weight Floor (0.0-0.5):", 
-    "stacking_min_radial_floor_note": "(0.0 = no floor)"
+    "stacking_min_radial_floor_note": "(0.0 = no floor)",
     "gui_memmap_title": "Memmap Options (coadd)",
     "gui_memmap_enable": "Use disk memmap",
     "gui_memmap_dir": "Memmap Folder"

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -284,7 +284,7 @@
     "num_workers_label": "Threads de Traitement :",
     "num_workers_note": "(0 = auto, basé sur les cœurs CPU)",
     "stacking_min_radial_floor_label": "Plancher Poids Radial Min (0.0-0.5) :", 
-    "stacking_min_radial_floor_note": "(0.0 = pas de plancher)"              
+    "stacking_min_radial_floor_note": "(0.0 = pas de plancher)",
     "gui_memmap_title": "Options memmap (coadd)",
     "gui_memmap_enable": "Utiliser memmap disque",
     "gui_memmap_dir": "Dossier memmap"


### PR DESCRIPTION
## Summary
- fix JSON syntax in French and English translation files so the localization module can load translations again

## Testing
- `python -m py_compile zemosaic_gui.py locales/zemosaic_localization.py`
- `python - <<'EOF'
from locales.zemosaic_localization import ZeMosaicLocalization
loc = ZeMosaicLocalization('fr')
print('window_title:', loc.get('window_title'))
print('gui_memmap_title:', loc.get('gui_memmap_title'))
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6859dbf242d8832f8677b7ceec7cdd27