### PR TITLE
Implement phase-specific auto-tuning of worker threads

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ It was born out of a need from an astrophotography Discord community called the 
 - Flexible FITS export with configurable `axis_order` (default `HWC`) and
   proper `BSCALE`/`BZERO` for float images
 - Option to save the final mosaic as 16-bit integer FITS
+- Phase-specific auto-tuning of worker threads (alignment capped at 50% of CPU threads)
 
 ---
 


### PR DESCRIPTION
## Summary
- auto-tune the number of worker threads per phase
- cap alignment/stacking threads to 50% of base workers
- document auto-tuning feature in the README

## Testing
- `python -m py_compile zemosaic_worker.py`
- `python -m compileall -q .`

------
https://chatgpt.com/codex/tasks/task_e_685a9c1b0f0c832fb818dcd9ffe01ff4