### PR TITLE
Enable memory mapped coadd by default and cache hot pixel masks

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ L’exécutable final se trouvera dans dist/zemosaic.exe.
 
 ✅ Les fichiers de traduction (locales/*.json) et les icônes (icon/zemosaic.ico) sont inclus automatiquement.
 
-### Memory-mapped coadd
+### Memory-mapped coadd (enabled by default)
 
 ```jsonc
 {
@@ -182,12 +182,13 @@ L’exécutable final se trouvera dans dist/zemosaic.exe.
 ```
 A final mosaic of 20 000 × 20 000 px in RGB needs ≈ 4.8 GB
 (4 × H × W × float32). Make sure the target disk/SSD has enough space.
+Hot pixel masks detected during preprocessing are also written to the temporary
+cache directory to further reduce memory usage.
 
 6 ▸ Quick CLI example
 ```bash
 run_zemosaic.py \
   --final_assembly_method reproject_coadd \
-  --coadd_use_memmap \
   --coadd_memmap_dir D:/ZeMosaic_memmap \
   --coadd_cleanup_memmap
 ```

--- a/zemosaic_config.json
+++ b/zemosaic_config.json
@@ -18,7 +18,7 @@
     "radial_shape_power": 2.0,
     "final_assembly_method": "reproject_coadd",
     "save_final_as_uint16": false,
-    "coadd_use_memmap": false,
+    "coadd_use_memmap": true,
     "coadd_memmap_dir": "",
     "coadd_cleanup_memmap": true
 }

--- a/zemosaic_config.py
+++ b/zemosaic_config.py
@@ -25,7 +25,7 @@ DEFAULT_CONFIG = {
     "radial_shape_power": 2.0,
     "final_assembly_method": "reproject_coadd", # Options: "reproject_coadd", "incremental",
     "save_final_as_uint16": False,
-    "coadd_use_memmap": False,
+    "coadd_use_memmap": True,
     "coadd_memmap_dir": "",
     "coadd_cleanup_memmap": True,
     # --- CLES POUR LE ROGNAGE DES MASTER TUILES ---

--- a/zemosaic_utils.py
+++ b/zemosaic_utils.py
@@ -434,12 +434,16 @@ def debayer_image(img_norm_01, bayer_pattern="GRBG", progress_callback=None):
     return color_img_rgb_uint16.astype(np.float32) / 65535.0
 
 
-def detect_and_correct_hot_pixels(image, threshold=3.0, neighborhood_size=5, progress_callback=None):
+def detect_and_correct_hot_pixels(image, threshold=3.0, neighborhood_size=5,
+                                  progress_callback=None, save_mask_path=None):
     def _log_util_hp(message, level="DEBUG_DETAIL"):
         if progress_callback and callable(progress_callback): progress_callback(f"  [ZU HotPix] {message}", None, level)
         else: print(f"  [ZU HotPix PRINTFALLBACK] {level}: {message}")
 
-    _log_util_hp(f"Début détection/correction HP. Threshold: {threshold}, Neighborhood: {neighborhood_size}", "DEBUG")
+    _log_util_hp(
+        f"Début détection/correction HP. Threshold: {threshold}, Neighborhood: {neighborhood_size}",
+        "DEBUG",
+    )
     if image is None: _log_util_hp("AVERT: Image entrée est None.", "WARN"); return None
     if not isinstance(image, np.ndarray): _log_util_hp(f"ERREUR: Entrée pas ndarray.", "ERROR"); return image 
 
@@ -451,27 +455,73 @@ def detect_and_correct_hot_pixels(image, threshold=3.0, neighborhood_size=5, pro
     _log_util_hp(f"Image {'couleur' if is_color else 'monochrome'}. Dtype original: {original_dtype}.", "DEBUG_DETAIL")
     
     try:
+        mask_accum = None
         if is_color:
+            mask_accum = np.zeros(img_float.shape, dtype=np.uint8)
             for c in range(img_float.shape[2]):
-                channel = img_float[:, :, c]; median_filtered = cv2.medianBlur(channel, neighborhood_size)
-                mean_local = cv2.blur(channel, ksize); mean_sq_local = cv2.blur(channel**2, ksize)
+                channel = img_float[:, :, c]
+                median_filtered = cv2.medianBlur(channel, neighborhood_size)
+                mean_local = cv2.blur(channel, ksize)
+                mean_sq_local = cv2.blur(channel**2, ksize)
                 std_dev_local = np.sqrt(np.maximum(mean_sq_local - mean_local**2, 0))
-                std_dev_floor = 1e-5 if np.issubdtype(channel.dtype, np.floating) else (1.0 / (np.iinfo(np.uint16).max if np.max(channel)<=1 else np.iinfo(channel.dtype).max if np.issubdtype(channel.dtype, np.integer) else (2**16-1) ) if np.max(channel)>1 else 1.0) # Simplifié
+                std_dev_floor = (
+                    1e-5
+                    if np.issubdtype(channel.dtype, np.floating)
+                    else (
+                        1.0
+                        / (
+                            np.iinfo(np.uint16).max
+                            if np.max(channel) <= 1
+                            else np.iinfo(channel.dtype).max
+                            if np.issubdtype(channel.dtype, np.integer)
+                            else (2**16 - 1)
+                        )
+                        if np.max(channel) > 1
+                        else 1.0
+                    )
+                )
                 std_dev_local_thresholded = np.maximum(std_dev_local, std_dev_floor)
                 hot_pixels_mask = channel > (median_filtered + threshold * std_dev_local_thresholded)
                 num_hot = np.sum(hot_pixels_mask)
-                if num_hot > 0: _log_util_hp(f"    Canal {c}: {num_hot} pixels chauds corrigés.", "DEBUG_DETAIL")
+                if num_hot > 0:
+                    _log_util_hp(f"    Canal {c}: {num_hot} pixels chauds corrigés.", "DEBUG_DETAIL")
                 channel[hot_pixels_mask] = median_filtered[hot_pixels_mask]
-        else: # Grayscale
+                mask_accum[..., c] = hot_pixels_mask
+        else:  # Grayscale
             median_filtered = cv2.medianBlur(img_float, neighborhood_size)
-            mean_local = cv2.blur(img_float, ksize); mean_sq_local = cv2.blur(img_float**2, ksize)
+            mean_local = cv2.blur(img_float, ksize)
+            mean_sq_local = cv2.blur(img_float**2, ksize)
             std_dev_local = np.sqrt(np.maximum(mean_sq_local - mean_local**2, 0))
-            std_dev_floor = 1e-5 if np.issubdtype(img_float.dtype, np.floating) else (1.0 / (np.iinfo(np.uint16).max if np.max(img_float)<=1 else np.iinfo(img_float.dtype).max if np.issubdtype(img_float.dtype, np.integer) else (2**16-1) ) if np.max(img_float)>1 else 1.0)
+            std_dev_floor = (
+                1e-5
+                if np.issubdtype(img_float.dtype, np.floating)
+                else (
+                    1.0
+                    / (
+                        np.iinfo(np.uint16).max
+                        if np.max(img_float) <= 1
+                        else np.iinfo(img_float.dtype).max
+                        if np.issubdtype(img_float.dtype, np.integer)
+                        else (2**16 - 1)
+                    )
+                    if np.max(img_float) > 1
+                    else 1.0
+                )
+            )
             std_dev_local_thresholded = np.maximum(std_dev_local, std_dev_floor)
             hot_pixels_mask = img_float > (median_filtered + threshold * std_dev_local_thresholded)
             num_hot = np.sum(hot_pixels_mask)
-            if num_hot > 0: _log_util_hp(f"  Image N&B: {num_hot} pixels chauds corrigés.", "DEBUG_DETAIL")
+            if num_hot > 0:
+                _log_util_hp(f"  Image N&B: {num_hot} pixels chauds corrigés.", "DEBUG_DETAIL")
             img_float[hot_pixels_mask] = median_filtered[hot_pixels_mask]
+            mask_accum = hot_pixels_mask.astype(np.uint8)
+        if save_mask_path:
+            try:
+                np.save(save_mask_path, mask_accum.astype(np.uint8))
+                _log_util_hp(f"Masque HP sauvegardé vers {os.path.basename(save_mask_path)}", "DEBUG_DETAIL")
+            except Exception as e_save:
+                _log_util_hp(f"ERREUR sauvegarde masque HP: {e_save}", "WARN")
+        del mask_accum
 
         if np.issubdtype(original_dtype, np.integer):
             d_info = np.iinfo(original_dtype)


### PR DESCRIPTION
## Summary
- enable `coadd_use_memmap` by default in config
- document memory mapped behaviour and hot pixel mask cache in README
- allow `detect_and_correct_hot_pixels` to save mask to disk
- save hot pixel masks in preprocessing stage
- pass mask path through pipeline

## Testing
- `python -m py_compile zemosaic_worker.py zemosaic_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_685aa9e583a4832fa4fd346fc555d0a8