### PR TITLE
Add auto frame limit feature

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -139,6 +139,8 @@
     "clusterstacks_info_start": "ClusterStacks: Clustering {num_files} raw files (fine threshold: {threshold}°)...",
     "clusterstacks_warn_no_centers": "ClusterStacks WARN: No valid celestial centers found for clustering.",
     "clusterstacks_info_finished": "ClusterStacks: {num_groups} Seestar stacks (fine groups) formed.",
+    "clusterstacks_info_groups_split_auto_limit": "Auto limit enabled: groups split from {original} to {new}, max {limit} frames (sample {shape})",
+    "clusterstacks_warn_auto_limit_failed": "Auto limit estimation failed: {error}",
     
     "getwcs_error_utils_unavailable": "GetWCS_Pretreat ERROR: zemosaic_utils module not available.",
     "getwcs_error_load_failed": "GetWCS_Pretreat ERROR: Failed to load '{filename}'.",
@@ -292,6 +294,7 @@
     "gui_memmap_title": "Memmap Options (coadd)",
     "gui_memmap_enable": "Use disk memmap",
     "gui_memmap_dir": "Memmap Folder",
-    "gui_memmap_cleanup": "Delete *.dat when finished"
+    "gui_memmap_cleanup": "Delete *.dat when finished",
+    "gui_auto_limit_frames": "Auto limit frames per master tile (system stability)"
 
 }

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -164,6 +164,8 @@
     "clusterstacks_info_start": "ClusterStacks : Groupement de {num_files} fichiers bruts (seuil fin : {threshold}°)...",
     "clusterstacks_warn_no_centers": "ClusterStacks AVERT : Aucun centre céleste valide trouvé pour le groupement.",
     "clusterstacks_info_finished": "ClusterStacks : {num_groups} stacks Seestar (groupes fins) formés.",
+    "clusterstacks_info_groups_split_auto_limit": "Limite auto activée : groupes divisés de {original} à {new}, max {limit} images (exemple {shape})",
+    "clusterstacks_warn_auto_limit_failed": "Échec estimation limite auto : {error}",
     
     "getwcs_error_utils_unavailable": "GetWCS_Pretreat ERREUR : Module zemosaic_utils non disponible.",
     "getwcs_error_load_failed": "GetWCS_Pretreat ERREUR : Échec chargement de '{filename}'.",
@@ -288,6 +290,7 @@
     "gui_memmap_title": "Options memmap (coadd)",
     "gui_memmap_enable": "Utiliser memmap disque",
     "gui_memmap_dir": "Dossier memmap",
-    "gui_memmap_cleanup": "Supprimer les *.dat à la fin"
+    "gui_memmap_cleanup": "Supprimer les *.dat à la fin",
+    "gui_auto_limit_frames": "Limiter automatiquement les images par master tile (stabilité système)"
     
 }

--- a/zemosaic_config.json
+++ b/zemosaic_config.json
@@ -20,5 +20,6 @@
     "save_final_as_uint16": false,
     "coadd_use_memmap": true,
     "coadd_memmap_dir": "",
-    "coadd_cleanup_memmap": true
+    "coadd_cleanup_memmap": true,
+    "auto_limit_frames_per_master_tile": true
 }

--- a/zemosaic_config.py
+++ b/zemosaic_config.py
@@ -28,6 +28,7 @@ DEFAULT_CONFIG = {
     "coadd_use_memmap": True,
     "coadd_memmap_dir": "",
     "coadd_cleanup_memmap": True,
+    "auto_limit_frames_per_master_tile": True,
     # --- CLES POUR LE ROGNAGE DES MASTER TUILES ---
     "apply_master_tile_crop": True,       # Désactivé par défaut
     "master_tile_crop_percent": 18.0      # Pourcentage par côté si activé (ex: 10%)

--- a/zemosaic_gui.py
+++ b/zemosaic_gui.py
@@ -179,6 +179,7 @@ class ZeMosaicGUI:
         self.use_memmap_var = tk.BooleanVar(value=self.config.get("coadd_use_memmap", False))
         self.mm_dir_var = tk.StringVar(value=self.config.get("coadd_memmap_dir", ""))
         self.cleanup_memmap_var = tk.BooleanVar(value=self.config.get("coadd_cleanup_memmap", True))
+        self.auto_limit_frames_var = tk.BooleanVar(value=self.config.get("auto_limit_frames_per_master_tile", True))
         # ---  ---
 
         self.translatable_widgets = {}
@@ -566,6 +567,7 @@ class ZeMosaicGUI:
         ttk.Entry(self.memmap_frame, textvariable=self.mm_dir_var, width=45).grid(row=1, column=1, sticky="we", padx=5, pady=3)
         ttk.Button(self.memmap_frame, text="…", command=self._browse_mm_dir).grid(row=1, column=2, padx=5, pady=3)
         ttk.Checkbutton(self.memmap_frame, text=self._tr("gui_memmap_cleanup", "Delete *.dat when finished"), variable=self.cleanup_memmap_var).grid(row=2, column=0, sticky="w", padx=5, pady=3)
+        ttk.Checkbutton(self.memmap_frame, text=self._tr("gui_auto_limit_frames", "Auto limit frames per master tile (system stability)"), variable=self.auto_limit_frames_var).grid(row=3, column=0, sticky="w", padx=5, pady=3, columnspan=2)
         self._on_assembly_method_change()
         
 
@@ -1133,7 +1135,8 @@ class ZeMosaicGUI:
             self.save_final_uint16_var.get(),
             self.use_memmap_var.get(),
             self.mm_dir_var.get(),
-            self.cleanup_memmap_var.get()
+            self.cleanup_memmap_var.get(),
+            self.auto_limit_frames_var.get()
             # --- FIN NOUVEAUX ARGUMENTS ---
         )
         


### PR DESCRIPTION
## Summary
- introduce config setting `auto_limit_frames_per_master_tile`
- provide GUI option and translations for automatic frame limiting
- split master tile groups when auto limit is enabled
- expose CLI flag `--no_auto_limit_frames`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685ae1090c28832fb9a03001dc7afc6f