### PR TITLE
Use processes for reproject coadd

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ It was born out of a need from an astrophotography Discord community called the 
   proper `BSCALE`/`BZERO` for float images
 - Option to save the final mosaic as 16-bit integer FITS
 - Phase-specific auto-tuning of worker threads (alignment capped at 50% of CPU threads)
+- Process-based parallelization for final mosaic assembly
+- Configurable `assembly_process_workers` to tune process count for assembly
 
 ---
 
@@ -108,6 +110,9 @@ Click "Start Hierarchical Mosaic"
 ✅ ASTAP installed + star catalogs (D50 or H18)
 
 ✅ FITS images (ideally calibrated, debayered or raw from Seestar)
+✅ Python multiprocessing enabled (ProcessPoolExecutor is used for assembly)
+✅ `assembly_process_workers` can be set in `zemosaic_config.json` to control
+   how many processes handle final mosaic assembly (0 = auto)
 
 🖥️ How to Run
 After installing Python and dependencies:
@@ -178,6 +183,7 @@ L’exécutable final se trouvera dans dist/zemosaic.exe.
   "coadd_use_memmap": true,
   "coadd_memmap_dir": "D:/ZeMosaic_memmap",
   "coadd_cleanup_memmap": true
+  "assembly_process_workers": 0
 }
 ```
 A final mosaic of 20 000 × 20 000 px in RGB needs ≈ 4.8 GB
@@ -190,7 +196,8 @@ cache directory to further reduce memory usage.
 run_zemosaic.py \
   --final_assembly_method reproject_coadd \
   --coadd_memmap_dir D:/ZeMosaic_memmap \
-  --coadd_cleanup_memmap
+  --coadd_cleanup_memmap \
+  --assembly_process_workers 4
 ```
 
 

--- a/zemosaic_config.json
+++ b/zemosaic_config.json
@@ -21,5 +21,6 @@
     "coadd_use_memmap": true,
     "coadd_memmap_dir": "",
     "coadd_cleanup_memmap": true,
+    "assembly_process_workers": 0,
     "auto_limit_frames_per_master_tile": true
 }

--- a/zemosaic_config.py
+++ b/zemosaic_config.py
@@ -28,6 +28,7 @@ DEFAULT_CONFIG = {
     "coadd_use_memmap": True,
     "coadd_memmap_dir": "",
     "coadd_cleanup_memmap": True,
+    "assembly_process_workers": 0,
     "auto_limit_frames_per_master_tile": True,
     # --- CLES POUR LE ROGNAGE DES MASTER TUILES ---
     "apply_master_tile_crop": True,       # Désactivé par défaut

--- a/zemosaic_gui.py
+++ b/zemosaic_gui.py
@@ -1136,7 +1136,8 @@ class ZeMosaicGUI:
             self.use_memmap_var.get(),
             self.mm_dir_var.get(),
             self.cleanup_memmap_var.get(),
-            self.auto_limit_frames_var.get()
+            self.auto_limit_frames_var.get(),
+            self.config.get("assembly_process_workers", 0)
             # --- FIN NOUVEAUX ARGUMENTS ---
         )
         

--- a/zemosaic_worker.py
+++ b/zemosaic_worker.py
@@ -12,7 +12,7 @@ import tempfile
 import glob
 import uuid
 
-from concurrent.futures import ThreadPoolExecutor, as_completed
+from concurrent.futures import ThreadPoolExecutor, ProcessPoolExecutor, as_completed, BrokenProcessPool
 
 # --- Configuration du Logging ---
 logger = logging.getLogger("ZeMosaicWorker")
@@ -929,6 +929,29 @@ def assemble_final_mosaic_incremental(
 
 
 
+def _reproject_and_coadd_channel_worker(channel_data_list, output_wcs_header, output_shape_hw, match_bg):
+    """Worker function to run reproject_and_coadd in a separate process."""
+    from astropy.wcs import WCS
+    from reproject.mosaicking import reproject_and_coadd
+    from reproject import reproject_interp
+    import numpy as np
+
+    final_wcs = WCS(output_wcs_header)
+    prepared_inputs = []
+    for arr, hdr in channel_data_list:
+        prepared_inputs.append((arr, WCS(hdr)))
+
+    stacked, coverage = reproject_and_coadd(
+        prepared_inputs,
+        output_projection=final_wcs,
+        shape_out=output_shape_hw,
+        reproject_function=reproject_interp,
+        combine_function="mean",
+        match_background=match_bg,
+    )
+    return stacked.astype(np.float32), coverage.astype(np.float32)
+
+
 def assemble_final_mosaic_with_reproject_coadd(
     master_tile_fits_with_wcs_list: list,
     final_output_wcs: WCS, # Type hint pour WCS d'Astropy
@@ -941,7 +964,8 @@ def assemble_final_mosaic_with_reproject_coadd(
     crop_percent: float = 0.0, # Pourcentage par côté, 0.0 = pas de rognage par défaut
     use_memmap: bool = False,
     memmap_dir: str | None = None,
-    cleanup_memmap: bool = True
+    cleanup_memmap: bool = True,
+    process_workers: int = 0
     # --- FIN NOUVEAUX PARAMÈTRES ---
 ):
     """
@@ -1020,7 +1044,9 @@ def assemble_final_mosaic_with_reproject_coadd(
                     _pcb(f"    ASM_REPROJ_COADD: AVERT - Option de rognage activée mais zemosaic_utils.crop_image_and_wcs non disponible.", lvl="WARN")
             # --- FIN APPLICATION DU ROGNAGE ---
 
-            input_data_all_tiles_HWC_processed.append((data_to_use_for_assembly, wcs_to_use_for_assembly))
+            input_data_all_tiles_HWC_processed.append(
+                (data_to_use_for_assembly, wcs_to_use_for_assembly.to_header())
+            )
 
         except MemoryError as e_mem_read: # ... (gestion MemoryError comme avant) ...
             _pcb("assemble_error_memory_reading_all_tiles", prog=None, lvl="ERROR", filename=os.path.basename(mt_path), error=str(e_mem_read)); logger.error(f"MemoryError lecture tuile {os.path.basename(mt_path)}:", exc_info=True); _log_memory_usage(progress_callback, f"MemoryError lecture tuile {i_tile_load+1}"); del input_data_all_tiles_HWC_processed; gc.collect(); return None, None 
@@ -1034,82 +1060,153 @@ def assemble_final_mosaic_with_reproject_coadd(
     _pcb("assemble_info_all_tiles_loaded_and_processed_reproject_coadd", prog=None, lvl="DEBUG", num_loaded_tiles=len(input_data_all_tiles_HWC_processed))
 
 
-    final_mosaic_stacked_channels_list = [] 
-    final_mosaic_coverage_map = None 
-    
-    for i_channel in range(n_channels):
-        # ... (log memory et info canal) ...
-        _log_memory_usage(progress_callback, f"Phase 5 (reproject_coadd) - Début canal {i_channel+1}")
-        _pcb("assemble_info_channel_processing_reproject_coadd", prog=None, lvl="INFO_DETAIL", channel_num=i_channel + 1, total_channels=n_channels)
-        
-        current_channel_input_data = []
-        # UTILISER input_data_all_tiles_HWC_processed ICI
-        for tile_data_hwc_processed, tile_wcs_processed in input_data_all_tiles_HWC_processed:
-            try:
-                # S'assurer que tile_data_hwc_processed a bien la dimension de canal
-                if tile_data_hwc_processed.ndim == 3 and tile_data_hwc_processed.shape[-1] > i_channel :
-                    channel_data_hw = tile_data_hwc_processed[..., i_channel].copy() # .copy() est important pour reproject
-                    current_channel_input_data.append((channel_data_hw, tile_wcs_processed))
-                elif tile_data_hwc_processed.ndim == 2 and i_channel == 0 : # Cas monochrome
-                    current_channel_input_data.append((tile_data_hwc_processed.copy(), tile_wcs_processed))
-                else:
-                    _pcb("assemble_error_channel_index_reproject_coadd_processed", lvl="ERROR", tile_shape=str(tile_data_hwc_processed.shape), channel_idx=i_channel)
-            except IndexError: # Devrait être attrapé par la condition de shape ci-dessus
-                _pcb("assemble_error_channel_index_reproject_coadd_indexerror", lvl="ERROR", tile_shape=str(tile_data_hwc_processed.shape), channel_idx=i_channel)
-                pass # Ne pas ajouter si le canal n'existe pas
-        
-        if not current_channel_input_data: # ... (gestion canal vide comme avant) ...
-            _pcb("assemble_warn_no_data_for_channel_reproject_coadd", lvl="WARN", channel_num=i_channel+1); black_channel = np.zeros(final_output_shape_hw, dtype=np.float32); final_mosaic_stacked_channels_list.append(black_channel)
-            if i_channel == 0 and final_mosaic_coverage_map is None: final_mosaic_coverage_map = np.zeros(final_output_shape_hw, dtype=np.float32)
-            _log_memory_usage(progress_callback, f"Phase 5 (reproject_coadd) - Fin canal {i_channel+1} (données manquantes)"); continue
+    final_mosaic_stacked_channels_list = [None] * n_channels
+    final_mosaic_coverage_map = None
 
-        try:
-            if use_memmap:
-                mm_sum = np.memmap(
-                    os.path.join(memmap_dir, f"sum_ch{i_channel}.dat"),
-                    dtype=np.float32, mode="w+", shape=final_output_shape_hw
+    # Préparation des données sérialisables par canal
+    per_channel_data = []
+    for i_channel in range(n_channels):
+        _log_memory_usage(progress_callback, f"Phase 5 (reproject_coadd) - Début canal {i_channel+1}")
+        _pcb(
+            "assemble_info_channel_processing_reproject_coadd",
+            prog=None,
+            lvl="INFO_DETAIL",
+            channel_num=i_channel + 1,
+            total_channels=n_channels,
+        )
+
+        ch_data = []
+        for tile_data_hwc_processed, tile_wcs_header in input_data_all_tiles_HWC_processed:
+            try:
+                if tile_data_hwc_processed.ndim == 3 and tile_data_hwc_processed.shape[-1] > i_channel:
+                    ch_data.append((tile_data_hwc_processed[..., i_channel].copy(), tile_wcs_header))
+                elif tile_data_hwc_processed.ndim == 2 and i_channel == 0:
+                    ch_data.append((tile_data_hwc_processed.copy(), tile_wcs_header))
+                else:
+                    _pcb(
+                        "assemble_error_channel_index_reproject_coadd_processed",
+                        lvl="ERROR",
+                        tile_shape=str(tile_data_hwc_processed.shape),
+                        channel_idx=i_channel,
+                    )
+            except IndexError:
+                _pcb(
+                    "assemble_error_channel_index_reproject_coadd_indexerror",
+                    lvl="ERROR",
+                    tile_shape=str(tile_data_hwc_processed.shape),
+                    channel_idx=i_channel,
                 )
-                mm_cov = np.memmap(
-                    os.path.join(memmap_dir, f"cov_ch{i_channel}.dat"),
-                    dtype=np.float32, mode="w+", shape=final_output_shape_hw
-                )
-                mm_sum[:] = 0.0
-                mm_cov[:] = 0.0
-                for img_hw, wcs in current_channel_input_data:
-                    reproj, footprint = reproject_interp((img_hw, wcs), final_output_wcs, shape_out=final_output_shape_hw)
-                    if match_bg:
-                        pass
-                    mm_sum += np.nan_to_num(reproj, nan=0.0)
-                    mm_cov += np.nan_to_num(footprint, nan=0.0)
-                    mm_sum.flush(); mm_cov.flush(); gc.collect()
-                stacked_channel_output = np.divide(mm_sum, mm_cov, out=np.zeros_like(mm_sum, dtype=np.float32), where=mm_cov > 0)
-                coverage_channel_output = mm_cov.copy()
-                mm_sum.flush(); mm_cov.flush(); del mm_sum, mm_cov
-            else:
-                _pcb(f"  Appel de reproject_and_coadd pour canal {i_channel+1} avec {len(current_channel_input_data)} images (potentiellement rognées). match_background={match_bg}", prog=None, lvl="DEBUG_DETAIL")
-                stacked_channel_output, coverage_channel_output = reproject_and_coadd(
-                    current_channel_input_data,
-                    output_projection=final_output_wcs,
-                    shape_out=final_output_shape_hw,
-                    reproject_function=reproject_interp,
-                    combine_function='mean',
-                    match_background=match_bg,
-                )
-                stacked_channel_output = stacked_channel_output.astype(np.float32)
-                coverage_channel_output = coverage_channel_output.astype(np.float32)
-            final_mosaic_stacked_channels_list.append(stacked_channel_output)
+        per_channel_data.append(ch_data)
+
+    final_output_wcs_header = final_output_wcs.to_header()
+
+    if use_memmap:
+        for i_channel, ch_data in enumerate(per_channel_data):
+            if not ch_data:
+                _pcb("assemble_warn_no_data_for_channel_reproject_coadd", lvl="WARN", channel_num=i_channel+1)
+                final_mosaic_stacked_channels_list[i_channel] = np.zeros(final_output_shape_hw, dtype=np.float32)
+                if i_channel == 0 and final_mosaic_coverage_map is None:
+                    final_mosaic_coverage_map = np.zeros(final_output_shape_hw, dtype=np.float32)
+                _log_memory_usage(progress_callback, f"Phase 5 (reproject_coadd) - Fin canal {i_channel+1} (données manquantes)")
+                continue
+
+            mm_sum = np.memmap(
+                os.path.join(memmap_dir, f"sum_ch{i_channel}.dat"),
+                dtype=np.float32,
+                mode="w+",
+                shape=final_output_shape_hw,
+            )
+            mm_cov = np.memmap(
+                os.path.join(memmap_dir, f"cov_ch{i_channel}.dat"),
+                dtype=np.float32,
+                mode="w+",
+                shape=final_output_shape_hw,
+            )
+            mm_sum[:] = 0.0
+            mm_cov[:] = 0.0
+            for img_hw, hdr in ch_data:
+                reproj, footprint = reproject_interp((img_hw, WCS(hdr)), final_output_wcs, shape_out=final_output_shape_hw)
+                if match_bg:
+                    pass
+                mm_sum += np.nan_to_num(reproj, nan=0.0)
+                mm_cov += np.nan_to_num(footprint, nan=0.0)
+                mm_sum.flush(); mm_cov.flush(); gc.collect()
+            stacked_channel_output = np.divide(
+                mm_sum,
+                mm_cov,
+                out=np.zeros_like(mm_sum, dtype=np.float32),
+                where=mm_cov > 0,
+            )
+            coverage_channel_output = mm_cov.copy()
+            mm_sum.flush(); mm_cov.flush(); del mm_sum, mm_cov
+
+            final_mosaic_stacked_channels_list[i_channel] = stacked_channel_output
             if i_channel == 0:
                 final_mosaic_coverage_map = coverage_channel_output
             _pcb("assemble_info_channel_processed_reproject_coadd", prog=None, lvl="INFO_DETAIL", channel_num=i_channel + 1)
-        
-        except MemoryError as e_mem_reproject: # ... (gestion MemoryError comme avant) ...
-            _pcb("assemble_error_memory_channel_reprojection_reproject_coadd", prog=None, lvl="ERROR", channel_num=i_channel + 1, error=str(e_mem_reproject)); logger.error(f"MemoryError reproject_and_coadd canal {i_channel + 1}:", exc_info=True); _log_memory_usage(progress_callback, f"MemoryError reproject_and_coadd canal {i_channel+1}"); del input_data_all_tiles_HWC_processed, current_channel_input_data, final_mosaic_stacked_channels_list, final_mosaic_coverage_map; gc.collect(); return None, None 
-        except Exception as e_reproject_ch: # ... (gestion autre Exception comme avant) ...
-            _pcb("assemble_error_channel_reprojection_failed_reproject_coadd", prog=None, lvl="ERROR", channel_num=i_channel + 1, error=str(e_reproject_ch)); logger.error(f"Erreur reproject_and_coadd canal {i_channel+1}:", exc_info=True); del input_data_all_tiles_HWC_processed, current_channel_input_data, final_mosaic_stacked_channels_list, final_mosaic_coverage_map; gc.collect(); return None, None
-        finally:
-            _log_memory_usage(progress_callback, f"Phase 5 (reproject_coadd) - Fin canal {i_channel+1} (avant del current_channel_input_data)")
-            del current_channel_input_data; gc.collect()
-            _log_memory_usage(progress_callback, f"Phase 5 (reproject_coadd) - Fin canal {i_channel+1} (après del current_channel_input_data)")
+            _log_memory_usage(progress_callback, f"Phase 5 (reproject_coadd) - Fin canal {i_channel+1} (après memmap)")
+    else:
+        max_procs = process_workers if process_workers and process_workers > 0 else min(os.cpu_count() or 1, n_channels)
+        _pcb(f"ASM_REPROJ_COADD: Using {max_procs} process workers", lvl="DEBUG_DETAIL")
+        with ProcessPoolExecutor(max_workers=max_procs) as ex:
+            future_map = {}
+            for i_channel, ch_data in enumerate(per_channel_data):
+                if not ch_data:
+                    _pcb("assemble_warn_no_data_for_channel_reproject_coadd", lvl="WARN", channel_num=i_channel+1)
+                    final_mosaic_stacked_channels_list[i_channel] = np.zeros(final_output_shape_hw, dtype=np.float32)
+                    if i_channel == 0 and final_mosaic_coverage_map is None:
+                        final_mosaic_coverage_map = np.zeros(final_output_shape_hw, dtype=np.float32)
+                    _log_memory_usage(progress_callback, f"Phase 5 (reproject_coadd) - Fin canal {i_channel+1} (données manquantes)")
+                    continue
+                future = ex.submit(_reproject_and_coadd_channel_worker, ch_data, final_output_wcs_header, final_output_shape_hw, match_bg)
+                future_map[future] = i_channel
+
+            for fut in as_completed(future_map):
+                idx = future_map[fut]
+                try:
+                    stacked_channel_output, coverage_channel_output = fut.result()
+                except MemoryError as e_mem_reproject:
+                    _pcb(
+                        "assemble_error_memory_channel_reprojection_reproject_coadd",
+                        prog=None,
+                        lvl="ERROR",
+                        channel_num=idx + 1,
+                        error=str(e_mem_reproject),
+                    )
+                    logger.error(
+                        f"MemoryError reproject_and_coadd canal {idx + 1}:",
+                        exc_info=True,
+                    )
+                    return None, None
+                except BrokenProcessPool as bpp:
+                    _pcb(
+                        "assemble_error_broken_process_pool_reproject_coadd",
+                        prog=None,
+                        lvl="ERROR",
+                        channel_num=idx + 1,
+                        error=str(bpp),
+                    )
+                    logger.error("BrokenProcessPool during channel reprojection", exc_info=True)
+                    return None, None
+                except Exception as e_reproject_ch:
+                    _pcb(
+                        "assemble_error_channel_reprojection_failed_reproject_coadd",
+                        prog=None,
+                        lvl="ERROR",
+                        channel_num=idx + 1,
+                        error=str(e_reproject_ch),
+                    )
+                    logger.error(
+                        f"Erreur reproject_and_coadd canal {idx + 1}:",
+                        exc_info=True,
+                    )
+                    return None, None
+
+                final_mosaic_stacked_channels_list[idx] = stacked_channel_output
+                if idx == 0:
+                    final_mosaic_coverage_map = coverage_channel_output
+                _pcb("assemble_info_channel_processed_reproject_coadd", prog=None, lvl="INFO_DETAIL", channel_num=idx + 1)
+                _log_memory_usage(progress_callback, f"Phase 5 (reproject_coadd) - Fin canal {idx+1}")
 
     _log_memory_usage(progress_callback, "Phase 5 (reproject_coadd) - Après traitement de tous les canaux")
     del input_data_all_tiles_HWC_processed # Supprimer la liste des données chargées
@@ -1168,6 +1265,7 @@ def run_hierarchical_mosaic(
     coadd_use_memmap_config: bool,
     coadd_memmap_dir_config: str,
     coadd_cleanup_memmap_config: bool,
+    assembly_process_workers_config: int,
     auto_limit_frames_per_master_tile_config: bool
 ):
     """
@@ -1580,7 +1678,8 @@ def run_hierarchical_mosaic(
             crop_percent=master_tile_crop_percent_config,
             use_memmap=coadd_use_memmap_config,
             memmap_dir=coadd_memmap_dir_config,
-            cleanup_memmap=coadd_cleanup_memmap_config
+            cleanup_memmap=coadd_cleanup_memmap_config,
+            process_workers=assembly_process_workers_config
             # --- FIN PASSAGE ---
         )
         log_key_phase5_failed = "run_error_phase5_assembly_failed_reproject_coadd"
@@ -1781,6 +1880,8 @@ if __name__ == "__main__":
                         help="Delete *.dat blocks when the run finishes")
     parser.add_argument("--no_auto_limit_frames", action="store_true",
                         help="Disable automatic frame limit per master tile")
+    parser.add_argument("--assembly_process_workers", type=int, default=None,
+                        help="Number of processes for final assembly (0=auto)")
     args = parser.parse_args()
 
     cfg = {}
@@ -1822,5 +1923,6 @@ if __name__ == "__main__":
         coadd_use_memmap_config=args.coadd_use_memmap or cfg.get("coadd_use_memmap", False),
         coadd_memmap_dir_config=args.coadd_memmap_dir or cfg.get("coadd_memmap_dir", None),
         coadd_cleanup_memmap_config=args.coadd_cleanup_memmap if args.coadd_cleanup_memmap else cfg.get("coadd_cleanup_memmap", True),
+        assembly_process_workers_config=args.assembly_process_workers if args.assembly_process_workers is not None else cfg.get("assembly_process_workers", 0),
         auto_limit_frames_per_master_tile_config=(not args.no_auto_limit_frames) and cfg.get("auto_limit_frames_per_master_tile", True),
     )


### PR DESCRIPTION
## Summary
- parallelize channel reprojection using `ProcessPoolExecutor`
- ensure per-channel data is serializable by passing WCS headers
- keep GUI progress updates for each channel
- note multiprocessing requirement and new feature in README
- allow controlling process count with `assembly_process_workers`

## Testing
- `python -m py_compile zemosaic_worker.py zemosaic_gui.py zemosaic_config.py`

------
https://chatgpt.com/codex/tasks/task_e_685b1628a214832f9126171699d0371b