### PR TITLE
Fix import error for BrokenProcessPool

### DIFF
--- a/zemosaic_worker.py
+++ b/zemosaic_worker.py
@@ -12,7 +12,9 @@ import tempfile
 import glob
 import uuid
 
-from concurrent.futures import ThreadPoolExecutor, ProcessPoolExecutor, as_completed, BrokenProcessPool
+from concurrent.futures import ThreadPoolExecutor, ProcessPoolExecutor, as_completed
+# BrokenProcessPool moved under concurrent.futures.process in modern Python
+from concurrent.futures.process import BrokenProcessPool
 
 
 # --- Configuration du Logging ---


### PR DESCRIPTION
## Summary
- adjust zemosaic_worker import to use `concurrent.futures.process.BrokenProcessPool`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685b1f1e87e0832f99a7de5def1507fb