### PR TITLE
Add configurable memory fraction for auto frame limit

### DIFF
--- a/zemosaic_config.json
+++ b/zemosaic_config.json
@@ -22,5 +22,6 @@
     "coadd_memmap_dir": "",
     "coadd_cleanup_memmap": true,
     "assembly_process_workers": 0,
-    "auto_limit_frames_per_master_tile": true
+    "auto_limit_frames_per_master_tile": true,
+    "auto_limit_memory_fraction": 0.3
 }

--- a/zemosaic_config.py
+++ b/zemosaic_config.py
@@ -30,6 +30,7 @@ DEFAULT_CONFIG = {
     "coadd_cleanup_memmap": True,
     "assembly_process_workers": 0,
     "auto_limit_frames_per_master_tile": True,
+    "auto_limit_memory_fraction": 0.3,
     # --- CLES POUR LE ROGNAGE DES MASTER TUILES ---
     "apply_master_tile_crop": True,       # Désactivé par défaut
     "master_tile_crop_percent": 18.0      # Pourcentage par côté si activé (ex: 10%)

--- a/zemosaic_gui.py
+++ b/zemosaic_gui.py
@@ -1147,7 +1147,8 @@ class ZeMosaicGUI:
             memmap_dir,
             self.cleanup_memmap_var.get(),
             self.auto_limit_frames_var.get(),
-            self.config.get("assembly_process_workers", 0)
+            self.config.get("assembly_process_workers", 0),
+            self.config.get("auto_limit_memory_fraction", 0.3)
             # --- FIN NOUVEAUX ARGUMENTS ---
         )
         

--- a/zemosaic_worker.py
+++ b/zemosaic_worker.py
@@ -1299,7 +1299,8 @@ def run_hierarchical_mosaic(
     coadd_memmap_dir_config: str,
     coadd_cleanup_memmap_config: bool,
     assembly_process_workers_config: int,
-    auto_limit_frames_per_master_tile_config: bool
+    auto_limit_frames_per_master_tile_config: bool,
+    auto_limit_memory_fraction_config: float
 ):
     """
     Orchestre le traitement de la mosaïque hiérarchique.
@@ -1515,7 +1516,13 @@ def run_hierarchical_mosaic(
             sample_shape = sample_arr.shape
             sample_arr = None
             available_bytes = psutil.virtual_memory().available
-            limit = max(1, int((available_bytes * 0.5) // (bytes_per_frame * 6)))
+            limit = max(
+                1,
+                int(
+                    (available_bytes * auto_limit_memory_fraction_config)
+                    // (bytes_per_frame * 6)
+                ),
+            )
             new_groups = []
             for g in seestar_stack_groups:
                 for i in range(0, len(g), limit):
@@ -1958,4 +1965,5 @@ if __name__ == "__main__":
         coadd_cleanup_memmap_config=args.coadd_cleanup_memmap if args.coadd_cleanup_memmap else cfg.get("coadd_cleanup_memmap", True),
         assembly_process_workers_config=args.assembly_process_workers if args.assembly_process_workers is not None else cfg.get("assembly_process_workers", 0),
         auto_limit_frames_per_master_tile_config=(not args.no_auto_limit_frames) and cfg.get("auto_limit_frames_per_master_tile", True),
+        auto_limit_memory_fraction_config=cfg.get("auto_limit_memory_fraction", 0.3),
     )


### PR DESCRIPTION
## Summary
- allow customizing the memory fraction used when automatically splitting frame groups
- pass `auto_limit_memory_fraction` from config to worker
- include new config option in GUI and CLI

## Testing
- `python -m py_compile zemosaic_worker.py zemosaic_gui.py zemosaic_config.py`

------
https://chatgpt.com/codex/tasks/task_e_685b9058a924832fa88a05d0a024de3d