### PR TITLE
Improve GUI updates during winsor rejection

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -295,6 +295,8 @@
     "gui_memmap_enable": "Use disk memmap",
     "gui_memmap_dir": "Memmap Folder",
     "gui_memmap_cleanup": "Delete *.dat when finished",
-    "gui_auto_limit_frames": "Auto limit frames per master tile (system stability)"
+    "gui_auto_limit_frames": "Auto limit frames per master tile (system stability)",
+    "reject_winsor_info_channel_progress": "Winsorized Sigma Clip processing channel {channel}...",
+    "reject_winsor_info_mono_progress": "Winsorized Sigma Clip processing monochrome data..."
 
 }

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -291,6 +291,8 @@
     "gui_memmap_enable": "Utiliser memmap disque",
     "gui_memmap_dir": "Dossier memmap",
     "gui_memmap_cleanup": "Supprimer les *.dat à la fin",
-    "gui_auto_limit_frames": "Limiter automatiquement les images par master tile (stabilité système)"
+    "gui_auto_limit_frames": "Limiter automatiquement les images par master tile (stabilité système)",
+    "reject_winsor_info_channel_progress": "Winsorized Sigma Clip : traitement du canal {channel}...",
+    "reject_winsor_info_mono_progress": "Winsorized Sigma Clip : traitement image monochrome..."
     
 }

--- a/zemosaic_align_stack.py
+++ b/zemosaic_align_stack.py
@@ -1,9 +1,10 @@
 # zemosaic_align_stack.py
 
 import numpy as np
-import traceback 
+import traceback
 import gc
 import logging # Added for logger fallback
+import time
 
 # dépendance Photutils
 PHOTOUTILS_AVAILABLE = False
@@ -960,6 +961,7 @@ def _reject_outliers_winsorized_sigma_clip(
         if is_color:
             _pcb("RejWinsor: Traitement image couleur (par canal).", lvl="DEBUG_DETAIL")
             for c_idx in range(stacked_array_NHDWC.shape[-1]): # Boucle sur les canaux R, G, B
+                _pcb("reject_winsor_info_channel_progress", lvl="INFO_DETAIL", channel=c_idx + 1)
                 _pcb(f"  RejWinsor: Canal {c_idx}...", lvl="DEBUG_VERY_DETAIL")
                 original_channel_data_NHW = stacked_array_NHDWC[..., c_idx].astype(np.float32, copy=False)
                 
@@ -999,7 +1001,9 @@ def _reject_outliers_winsorized_sigma_clip(
                 
                 num_rejected_ch = np.sum(pixels_to_reject_this_channel)
                 _pcb(f"    RejWinsor: Canal {c_idx}, {num_rejected_ch} pixels rejetés.", lvl="DEBUG_DETAIL")
+                time.sleep(0)
         else: # Image monochrome (N, H, W)
+            _pcb("reject_winsor_info_mono_progress", lvl="INFO_DETAIL")
             _pcb("RejWinsor: Traitement image monochrome.", lvl="DEBUG_DETAIL")
             original_data_NHW = stacked_array_NHDWC.astype(np.float32, copy=False)
 


### PR DESCRIPTION
## Summary
- add `time` import to align stack helpers
- emit progress callbacks for each channel in Winsorized sigma clipping
- add translations for new progress messages

## Testing
- `python -m py_compile zemosaic_align_stack.py`
- `python -m py_compile zemosaic_gui.py zemosaic_worker.py`


------
https://chatgpt.com/codex/tasks/task_e_685bb70b84b0832fb56fc4921650abff