### PR TITLE
Fix multiprocessing startup error

### DIFF
--- a/run_zemosaic.py
+++ b/run_zemosaic.py
@@ -1,8 +1,9 @@
 # zemosaic/run_zemosaic.py
-import sys # Ajout pour sys.path et sys.modules
+import sys  # Ajout pour sys.path et sys.modules
+import multiprocessing
 # import reproject # L'import direct ici n'est pas crucial, mais ne fait pas de mal
 import tkinter as tk
-from tkinter import messagebox # Nécessaire pour la messagebox d'erreur critique
+from tkinter import messagebox  # Nécessaire pour la messagebox d'erreur critique
 
 # --- Impression de débogage initiale ---
 print("--- run_zemosaic.py: DÉBUT DES IMPORTS ---")
@@ -88,6 +89,7 @@ def main():
     print("--- run_zemosaic.py: mainloop() terminée ---")
 
 if __name__ == "__main__":
+    multiprocessing.freeze_support()
     print("Lancement de ZeMosaic via run_zemosaic.py (__name__ == '__main__')...")
     main()
     print("ZeMosaic terminé (sortie de __main__).")

--- a/zemosaic_gui.py
+++ b/zemosaic_gui.py
@@ -1125,10 +1125,9 @@ class ZeMosaicGUI:
             )
 
         worker_args = (
-            input_dir, output_dir, astap_exe, astap_data, 
-            astap_radius_val, astap_downsample_val, astap_sensitivity_val, 
-            cluster_thresh_val, 
-            self._log_message, 
+            input_dir, output_dir, astap_exe, astap_data,
+            astap_radius_val, astap_downsample_val, astap_sensitivity_val,
+            cluster_thresh_val,
             stack_norm_method,
             stack_weight_method,
             stack_reject_algo,


### PR DESCRIPTION
## Summary
- avoid passing GUI bound method to the worker process
- add `multiprocessing.freeze_support()` in the entry point

## Testing
- `python -m py_compile run_zemosaic.py zemosaic_gui.py`

------
https://chatgpt.com/codex/tasks/task_e_685bbd354dd0832f8b29d4a40f059bb4