### PR TITLE
Fix winsorization axis in parallel mode

### DIFF
--- a/zemosaic_align_stack.py
+++ b/zemosaic_align_stack.py
@@ -903,9 +903,15 @@ def _reject_outliers_kappa_sigma(stacked_array_NHDWC, sigma_low, sigma_high, pro
 
 
 def _apply_winsor_single(args):
-    """Helper for parallel winsorization."""
+    """Helper for parallel winsorization.
+
+    Ensures winsorization is applied along the image axis (axis=0) to
+    preserve per-pixel statistics. ``scipy.stats.mstats.winsorize`` flattens
+    the array when no axis is provided which would incorrectly clip signal
+    across the entire stack.
+    """
     arr, limits = args
-    return winsorize_func(arr, limits)
+    return np.asarray(winsorize_func(arr, limits, axis=0))
 
 
 def parallel_rejwinsor(channels, limits, max_workers, progress_callback=None):


### PR DESCRIPTION
## Summary
- keep per-pixel stats intact when winsorizing in parallel

## Testing
- `python -m py_compile zemosaic_align_stack.py`

------
https://chatgpt.com/codex/tasks/task_e_685be6b77004832f8244dfdc6037e3b7