### PR TITLE
Fix ASTAP log timing

### DIFF
--- a/zemosaic_astrometry.py
+++ b/zemosaic_astrometry.py
@@ -322,6 +322,12 @@ def solve_with_astap(image_fits_path: str,
 
         if rc_astap == 0:
             log_path = os.path.join(current_image_dir, "astap.log")
+            if not os.path.exists(log_path):
+                for _ in range(20):
+                    if os.path.exists(log_path):
+                        break
+                    time.sleep(0.1)
+
             if os.path.exists(log_path):
                 try:
                     with open(log_path, "r") as f:


### PR DESCRIPTION
## Summary
- wait up to 2s for the `astap.log` file to appear after running ASTAP

## Testing
- `python -m py_compile zemosaic_astrometry.py zemosaic_utils.py zemosaic_align_stack.py zemosaic_gui.py zemosaic_worker.py run_zemosaic.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c493d2f0c832fb6b4c75a3a044c04