### PR TITLE
Write WCS to FITS and load lazily

### DIFF
--- a/zemosaic_worker.py
+++ b/zemosaic_worker.py
@@ -11,6 +11,7 @@ import psutil
 import tempfile
 import glob
 import uuid
+import warnings
 
 from concurrent.futures import ThreadPoolExecutor, ProcessPoolExecutor, as_completed
 # BrokenProcessPool moved under concurrent.futures.process in modern Python
@@ -305,14 +306,30 @@ def _calculate_final_mosaic_grid(panel_wcs_list: list, panel_shapes_hw_list: lis
         return None, None
 
 
+def _load_wcs_from_fits(file_path: str) -> WCS:
+    """Lit l'en-tête d'un FITS et retourne un objet WCS léger."""
+    if not (file_path and os.path.isfile(file_path)):
+        raise FileNotFoundError(f"FITS not found: {file_path}")
+    hdr = fits.getheader(file_path, ext=0)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        return WCS(hdr, naxis=2, relax=True)
+
+
 def cluster_seestar_stacks(all_raw_files_with_info: list, stack_threshold_deg: float, progress_callback: callable):
     if not (ASTROPY_AVAILABLE and SkyCoord and u): _log_and_callback("clusterstacks_error_astropy_unavailable", level="ERROR", callback=progress_callback); return []
     if not all_raw_files_with_info: _log_and_callback("clusterstacks_warn_no_raw_info", level="WARN", callback=progress_callback); return []
     _log_and_callback("clusterstacks_info_start", num_files=len(all_raw_files_with_info), threshold=stack_threshold_deg, level="INFO", callback=progress_callback)
     panel_centers_sky = []; panel_data_for_clustering = []
     for i, info in enumerate(all_raw_files_with_info):
-        wcs_obj = info['wcs']
-        if not (wcs_obj and wcs_obj.is_celestial): continue
+        wcs_obj = info.get('wcs')
+        if wcs_obj is None:
+            try:
+                wcs_obj = _load_wcs_from_fits(info.get('path_raw'))
+            except Exception:
+                continue
+        if not (wcs_obj and wcs_obj.is_celestial):
+            continue
         try:
             if wcs_obj.pixel_shape: center_world = wcs_obj.pixel_to_world(wcs_obj.pixel_shape[0]/2.0, wcs_obj.pixel_shape[1]/2.0)
             elif hasattr(wcs_obj.wcs, 'crval'): center_world = SkyCoord(ra=wcs_obj.wcs.crval[0]*u.deg, dec=wcs_obj.wcs.crval[1]*u.deg, frame='icrs')
@@ -471,6 +488,10 @@ def get_wcs_and_pretreat_raw_file(file_path: str, astap_exe_path: str, astap_dat
         
         if wcs_brute and wcs_brute.is_celestial: # Re-vérifier après la tentative de set_pixel_shape
             _pcb_local("getwcs_info_pretreatment_wcs_ok", lvl="DEBUG", filename=filename)
+            try:
+                zemosaic_astrometry._write_wcs_to_fits(file_path, wcs_brute, progress_callback)
+            except Exception:
+                pass
             return img_data_processed_adu, wcs_brute, header_orig, hp_mask_path  # header_orig peut avoir été mis à jour par ASTAP
         # else: tombe dans le bloc de déplacement ci-dessous
 
@@ -578,6 +599,11 @@ def create_master_tile(
     
     ref_info_for_tile = seestar_stack_group_info[reference_image_index_in_group]
     wcs_for_master_tile = ref_info_for_tile.get('wcs')
+    if wcs_for_master_tile is None:
+        try:
+            wcs_for_master_tile = _load_wcs_from_fits(ref_info_for_tile.get('path_raw'))
+        except Exception:
+            wcs_for_master_tile = None
     # Le header est un dict venant du cache, il faut le convertir en objet fits.Header si besoin
     header_dict_for_master_tile_base = ref_info_for_tile.get('header') 
 
@@ -774,7 +800,7 @@ def create_master_tile(
         )
         pcb_tile(f"{func_id_log_base}_info_saved", prog=None, lvl="INFO_DETAIL", tile_id=tile_id, format_type='float32', filename=os.path.basename(temp_fits_filepath))
         # pcb_tile(f"{func_id_log_base}_info_saving_finished", prog=None, lvl="DEBUG_DETAIL", tile_id=tile_id)
-        return temp_fits_filepath, wcs_for_master_tile
+        return temp_fits_filepath
         
     except Exception as e_save_mt:
         pcb_tile(f"{func_id_log_base}_error_saving", prog=None, lvl="ERROR", tile_id=tile_id, error=str(e_save_mt))
@@ -836,7 +862,7 @@ def assemble_final_mosaic_incremental(
         pcb_asm("assemble_error_allocating_accumulators", prog=None, lvl="ERROR", error=str(e_acc)); logger.error("Erreur allocation accumulateurs (incrémental).", exc_info=True); return None, None
     pcb_asm("assemble_info_accumulators_allocated", prog=None, lvl="DEBUG_DETAIL")
 
-    for tile_idx, (tile_path, mt_wcs_obj_original) in enumerate(master_tile_fits_with_wcs_list, 1):
+    for tile_idx, tile_path in enumerate(master_tile_fits_with_wcs_list, 1):
         pcb_asm("assemble_info_processing_tile", prog=None, lvl="INFO_DETAIL", tile_num=tile_idx, total_tiles=num_master_tiles, filename=os.path.basename(tile_path))
         
         # Initialisation des variables pour ce scope de boucle
@@ -846,11 +872,11 @@ def assemble_final_mosaic_incremental(
         tile_processed_successfully_this_iteration = False
 
         try:
-            with fits.open(tile_path, memmap=False, do_not_scale_image_data=True) as hdul: # memmap=False est plus sûr pour éviter problèmes de fichiers ouverts
-                if not hdul or not hasattr(hdul[0], 'data') or hdul[0].data is None: 
+            with fits.open(tile_path, memmap=False, do_not_scale_image_data=True) as hdul:  # memmap=False est plus sûr pour éviter problèmes de fichiers ouverts
+                if not hdul or not hasattr(hdul[0], 'data') or hdul[0].data is None:
                     pcb_asm("assemble_warn_tile_empty_or_no_data_inc", prog=None, lvl="WARN", filename=os.path.basename(tile_path))
-                    continue 
-                
+                    continue
+
                 data_tile_cxhxw = hdul[0].data.astype(np.float32)
                 if data_tile_cxhxw.ndim == 3 and data_tile_cxhxw.shape[0] == n_channels:
                     current_tile_data_hwc = np.moveaxis(data_tile_cxhxw, 0, -1)
@@ -862,22 +888,26 @@ def assemble_final_mosaic_incremental(
             del data_tile_cxhxw; gc.collect()
 
             data_to_use_for_reproject = current_tile_data_hwc
-            wcs_to_use_for_reproject = mt_wcs_obj_original
+            try:
+                wcs_to_use_for_reproject = _load_wcs_from_fits(tile_path)
+            except Exception:
+                pcb_asm("assemble_warn_tile_wcs_load_failed_inc", prog=None, lvl="WARN", filename=os.path.basename(tile_path))
+                continue
 
-            if apply_crop and crop_percent > 1e-3: # Appliquer si crop_percent significatif
+            if apply_crop and crop_percent > 1e-3:
                 if ZEMOSAIC_UTILS_AVAILABLE and hasattr(zemosaic_utils, 'crop_image_and_wcs'):
                     pcb_asm(f"  ASM_INC: Rognage {crop_percent:.1f}% pour tuile {os.path.basename(tile_path)}", lvl="DEBUG_DETAIL")
                     cropped_data, cropped_wcs = zemosaic_utils.crop_image_and_wcs(
-                        current_tile_data_hwc, mt_wcs_obj_original, crop_percent / 100.0, progress_callback
+                        current_tile_data_hwc, wcs_to_use_for_reproject, crop_percent / 100.0, progress_callback
                     )
-                    if cropped_data is not None and cropped_wcs is not None:
-                        data_to_use_for_reproject = cropped_data
-                        wcs_to_use_for_reproject = cropped_wcs
-                        pcb_asm(f"    Nouvelle shape après rognage: {data_to_use_for_reproject.shape[:2]}", lvl="DEBUG_VERY_DETAIL")
-                    else:
-                        pcb_asm(f"  ASM_INC: AVERT - Rognage a échoué pour tuile {os.path.basename(tile_path)}. Utilisation tuile non rognée.", lvl="WARN")
+                if cropped_data is not None and cropped_wcs is not None:
+                    data_to_use_for_reproject = cropped_data
+                    wcs_to_use_for_reproject = cropped_wcs
+                    pcb_asm(f"    Nouvelle shape après rognage: {data_to_use_for_reproject.shape[:2]}", lvl="DEBUG_VERY_DETAIL")
                 else:
-                    pcb_asm(f"  ASM_INC: AVERT - Option rognage activée mais zemosaic_utils.crop_image_and_wcs non dispo.", lvl="WARN")
+                    pcb_asm(f"  ASM_INC: AVERT - Rognage a échoué pour tuile {os.path.basename(tile_path)}. Utilisation tuile non rognée.", lvl="WARN")
+            else:
+                pcb_asm(f"  ASM_INC: AVERT - Option rognage activée mais zemosaic_utils.crop_image_and_wcs non dispo.", lvl="WARN")
             
             if data_to_use_for_reproject is None or wcs_to_use_for_reproject is None: 
                 pcb_asm(f"  ASM_INC: Données ou WCS pour reprojection sont None pour tuile {os.path.basename(tile_path)}, ignorée.", lvl="WARN")
@@ -1033,7 +1063,7 @@ def assemble_final_mosaic_reproject_coadd(
     # Ces données et WCS seront potentiellement ceux des images rognées.
     input_data_all_tiles_HWC_processed = [] 
     
-    for i_tile_load, (mt_path, mt_wcs_obj_original) in enumerate(master_tile_fits_with_wcs_list):
+    for i_tile_load, mt_path in enumerate(master_tile_fits_with_wcs_list):
         try:
             _pcb(f"  ASM_REPROJ_COADD: Lecture et prétraitement (rognage si actif) Master Tile {i_tile_load+1}/{num_master_tiles} '{os.path.basename(mt_path)}'", prog=None, lvl="DEBUG_VERY_DETAIL")
             
@@ -1056,14 +1086,18 @@ def assemble_final_mosaic_reproject_coadd(
             
             # --- APPLICATION DU ROGNAGE SI ACTIVÉ ---
             data_to_use_for_assembly = current_tile_data_hwc
-            wcs_to_use_for_assembly = mt_wcs_obj_original
+            try:
+                wcs_to_use_for_assembly = _load_wcs_from_fits(mt_path)
+            except Exception:
+                _pcb("assemble_warn_tile_wcs_load_failed_reproject_coadd", prog=None, lvl="WARN", filename=os.path.basename(mt_path))
+                continue
 
             if apply_crop and crop_percent > 1e-3: # Appliquer si crop_percent > 0 (avec une petite tolérance)
                 if ZEMOSAIC_UTILS_AVAILABLE and hasattr(zemosaic_utils, 'crop_image_and_wcs'):
                     _pcb(f"    ASM_REPROJ_COADD: Rognage {crop_percent:.1f}% pour tuile {os.path.basename(mt_path)}", lvl="DEBUG_DETAIL")
                     cropped_data, cropped_wcs = zemosaic_utils.crop_image_and_wcs(
-                        current_tile_data_hwc, 
-                        mt_wcs_obj_original, 
+                        current_tile_data_hwc,
+                        wcs_to_use_for_assembly,
                         crop_percent / 100.0, # La fonction attend une fraction (0.0 à 1.0)
                         progress_callback=progress_callback
                     )
@@ -1483,13 +1517,13 @@ def run_hierarchical_mosaic(
                     cached_image_path = os.path.join(temp_image_cache_dir, cache_file_basename)
                     try:
                         np.save(cached_image_path, img_data_adu)
-                        # Stocker les informations pour les phases suivantes
+                        # Stocker les informations pour les phases suivantes (WCS écrit dans le FITS)
                         all_raw_files_processed_info_dict[file_path_original] = {
-                            'path_raw': file_path_original, 
+                            'path_raw': file_path_original,
                             'path_preprocessed_cache': cached_image_path,
                             'path_hotpix_mask': hp_mask_path,
-                            'wcs': wcs_obj_solved,
-                            'header': header_obj_updated
+                            'header': header_obj_updated,
+                            'shape_hw': img_data_adu.shape[:2]
                         }
                         # pcb(f"Phase 1: Fichier '{os.path.basename(file_path_original)}' traité et mis en cache.", prog=prog_step_phase1, lvl="DEBUG_VERY_DETAIL") # Optionnel
                     except Exception as e_save_npy:
@@ -1645,10 +1679,10 @@ def run_hierarchical_mosaic(
             
             prog_step_phase3 = base_progress_phase3 + int(PROGRESS_WEIGHT_PHASE3_MASTER_TILES * (tiles_processed_count_ph3 / max(1, num_seestar_stacks_to_process)))
             try:
-                mt_result_path, mt_result_wcs = future.result()
-                if mt_result_path and mt_result_wcs: 
-                    master_tiles_results_list_temp[group_index_original] = (mt_result_path, mt_result_wcs)
-                else: 
+                mt_result_path = future.result()
+                if mt_result_path:
+                    master_tiles_results_list_temp[group_index_original] = mt_result_path
+                else:
                     pcb("run_warn_phase3_master_tile_creation_failed_thread", prog=prog_step_phase3, lvl="WARN", stack_num=group_index_original + 1)
             except Exception as exc_thread_ph3: 
                 pcb("run_error_phase3_thread_exception", prog=prog_step_phase3, lvl="ERROR", stack_num=group_index_original + 1, error=str(exc_thread_ph3))
@@ -1695,10 +1729,17 @@ def run_hierarchical_mosaic(
     base_progress_phase4 = current_global_progress
     _log_memory_usage(progress_callback, "Début Phase 4 (Calcul Grille)")
     pcb("run_info_phase4_started", prog=base_progress_phase4, lvl="INFO")
-    wcs_list_for_final_grid = []; shapes_list_for_final_grid_hw = []
-    for mt_path_iter,mt_wcs_iter in master_tiles_results_list:
-        # ... (logique de récupération shape, inchangée) ...
-        if not (mt_path_iter and os.path.exists(mt_path_iter) and mt_wcs_iter and mt_wcs_iter.is_celestial): pcb("run_warn_phase4_invalid_master_tile_for_grid", prog=None, lvl="WARN", path=os.path.basename(mt_path_iter if mt_path_iter else "N/A_path")); continue
+    wcs_list_for_final_grid = []
+    shapes_list_for_final_grid_hw = []
+    for mt_path_iter in master_tiles_results_list:
+        if not (mt_path_iter and os.path.exists(mt_path_iter)):
+            pcb("run_warn_phase4_invalid_master_tile_for_grid", prog=None, lvl="WARN", path=os.path.basename(mt_path_iter if mt_path_iter else "N/A_path"));
+            continue
+        try:
+            mt_wcs_iter = _load_wcs_from_fits(mt_path_iter)
+        except Exception:
+            pcb("run_warn_phase4_invalid_master_tile_for_grid", prog=None, lvl="WARN", path=os.path.basename(mt_path_iter))
+            continue
         try:
             h_mt_loc,w_mt_loc=0,0
             if mt_wcs_iter.pixel_shape and mt_wcs_iter.pixel_shape[0] > 0 and mt_wcs_iter.pixel_shape[1] > 0 : h_mt_loc,w_mt_loc=mt_wcs_iter.pixel_shape[1],mt_wcs_iter.pixel_shape[0] 
@@ -1728,9 +1769,9 @@ def run_hierarchical_mosaic(
     _log_memory_usage(progress_callback, f"Début Phase 5 (Méthode: {final_assembly_method_config}, Rognage MT Appliqué: {apply_master_tile_crop_config}, %Rognage: {master_tile_crop_percent_config if apply_master_tile_crop_config else 'N/A'})") # Log mis à jour
     
     valid_master_tiles_for_assembly = []
-    for mt_p, mt_w in master_tiles_results_list:
-        if mt_p and os.path.exists(mt_p) and mt_w and mt_w.is_celestial: 
-            valid_master_tiles_for_assembly.append((mt_p, mt_w))
+    for mt_p in master_tiles_results_list:
+        if mt_p and os.path.exists(mt_p):
+            valid_master_tiles_for_assembly.append(mt_p)
         else:
             pcb("run_warn_phase5_invalid_tile_skipped_for_assembly", prog=None, lvl="WARN", filename=os.path.basename(mt_p if mt_p else 'N/A')) # Clé de log plus spécifique
             


### PR DESCRIPTION
## Summary
- add helper to inject WCS solution directly into a FITS header
- add function to read WCS from a FITS file on demand
- store only headers and paths for raw files
- load WCS from disk when clustering, creating master tiles and assembling

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685c61798350832fa6bc71620075fe82