### PR TITLE
Fix incremental mosaic holes

### DIFF
--- a/zemosaic_align_stack.py
+++ b/zemosaic_align_stack.py
@@ -721,7 +721,7 @@ def _calculate_image_weights_noise_fwhm(image_list: list[np.ndarray | None],
                 threshold_daofind_val = 5.0 * stddev_glob
 
             # S'assurer que threshold_daofind_val est un scalaire positif
-            if hasattr(threshold_daofind_val, 'mean'): threshold_daofind_val = np.abs(np.mean(threshold_daofind_val))
+            if hasattr(threshold_daofind_val, 'mean'): threshold_daofind_val = np.abs(np.nanmean(threshold_daofind_val))
             else: threshold_daofind_val = np.abs(threshold_daofind_val)
             if threshold_daofind_val < 1e-5 : threshold_daofind_val = 1e-5 # Minimum seuil
 
@@ -740,7 +740,7 @@ def _calculate_image_weights_noise_fwhm(image_list: list[np.ndarray | None],
 
             # Utilisation de SourceCatalog pour les propriétés morphologiques
             threshold_seg_val = 1.5 * (bkg_obj.background_rms if bkg_obj and hasattr(bkg_obj, 'background_rms') else np.nanstd(data_subtracted))
-            if hasattr(threshold_seg_val, 'mean'): threshold_seg_val = np.abs(np.mean(threshold_seg_val))
+            if hasattr(threshold_seg_val, 'mean'): threshold_seg_val = np.abs(np.nanmean(threshold_seg_val))
             else: threshold_seg_val = np.abs(threshold_seg_val)
             if threshold_seg_val < 1e-5 : threshold_seg_val = 1e-5
 

--- a/zemosaic_worker.py
+++ b/zemosaic_worker.py
@@ -340,13 +340,15 @@ def reproject_tile_to_mosaic(file_path: str, tile_wcs: WCS, output_wcs: WCS,
     weight_orig = np.outer(wy, wx).astype(np.float32)
 
     proj_weight, _ = reproject_interp((weight_orig, tile_wcs), output_wcs,
-                                      shape_out=output_shape_hw, order='bilinear', parallel=False)
+                                      shape_out=output_shape_hw, order='bilinear', parallel=False,
+                                      fill_value=np.nan)
     proj_weight = np.nan_to_num(proj_weight, nan=0.0).astype(np.float32)
 
     reproj_stack = np.zeros((output_shape_hw[0], output_shape_hw[1], n_channels), dtype=np.float32)
     for i in range(n_channels):
         reproj, _ = reproject_interp((data_hwc[..., i], tile_wcs), output_wcs,
-                                     shape_out=output_shape_hw, order='bilinear', parallel=False)
+                                     shape_out=output_shape_hw, order='bilinear', parallel=False,
+                                     fill_value=np.nan)
         reproj_stack[..., i] = reproj.astype(np.float32)
 
     mask = proj_weight > 1e-6
@@ -1244,7 +1246,7 @@ def assemble_final_mosaic_reproject_coadd(
             mm_sum[:] = 0.0
             mm_cov[:] = 0.0
             for img_hw, hdr in ch_data:
-                reproj, footprint = reproject_interp((img_hw, WCS(hdr)), final_output_wcs, shape_out=final_output_shape_hw)
+                reproj, footprint = reproject_interp((img_hw, WCS(hdr)), final_output_wcs, shape_out=final_output_shape_hw, fill_value=np.nan)
                 if match_bg:
                     # --- Background matching for memmap path ---
                     overlap_mask = (footprint > 0) & (mm_cov > 0)


### PR DESCRIPTION
## Summary
- prevent zero padding in incremental mode by using `fill_value=np.nan` for all `reproject_interp` calls
- ensure NaN-safe average when computing detection thresholds

## Testing
- `python -m py_compile zemosaic_worker.py zemosaic_align_stack.py`

------
https://chatgpt.com/codex/tasks/task_e_685d09645d0c832f8e916e8084f5c33a