### PR TITLE
Fix missing arguments for incremental mosaic assembly

### DIFF
--- a/zemosaic_worker.py
+++ b/zemosaic_worker.py
@@ -1761,9 +1761,13 @@ def run_hierarchical_mosaic(
             pcb("run_error_phase5_inc_func_missing", prog=None, lvl="CRITICAL"); return
         pcb("run_info_phase5_started_incremental", prog=base_progress_phase5, lvl="INFO")
         final_mosaic_data_HWC, final_mosaic_coverage_HW = assemble_final_mosaic_incremental(
-            master_tile_fits_with_wcs_list=valid_master_tiles_for_assembly, 
-            final_output_wcs=final_output_wcs, 
+            master_tile_fits_with_wcs_list=valid_master_tiles_for_assembly,
+            final_output_wcs=final_output_wcs,
             final_output_shape_hw=final_output_shape_hw,
+            progress_callback=progress_callback,
+            n_channels=3,
+            apply_crop=apply_master_tile_crop_config,
+            crop_percent=master_tile_crop_percent_config,
             # --- FIN PASSAGE ---
         )
         log_key_phase5_failed = "run_error_phase5_assembly_failed_incremental"


### PR DESCRIPTION
## Summary
- fix a `TypeError` when using incremental mode
- include the progress callback and crop options when calling `assemble_final_mosaic_incremental`

## Testing
- `python -m py_compile zemosaic_worker.py`
- `python -m py_compile run_zemosaic.py zemosaic_utils.py zemosaic_gui.py zemosaic_align_stack.py zemosaic_astrometry.py zemosaic_config.py`


------
https://chatgpt.com/codex/tasks/task_e_685d1e404cb8832f9ff1413f78828ba8