### PR TITLE
Fix daemon aware executor in incremental mosaic

### DIFF
--- a/zemosaic_worker.py
+++ b/zemosaic_worker.py
@@ -955,7 +955,8 @@ def assemble_final_mosaic_incremental(
         max_procs = min(os.cpu_count() or 1, len(master_tile_fits_with_wcs_list))
     pcb_asm(f"ASM_INC: Using {max_procs} process workers", lvl="DEBUG_DETAIL")
 
-    Executor = ProcessPoolExecutor
+    parent_is_daemon = multiprocessing.current_process().daemon
+    Executor = ThreadPoolExecutor if parent_is_daemon else ProcessPoolExecutor
 
 
     try:


### PR DESCRIPTION
## Summary
- detect if the parent process is daemon and select ThreadPoolExecutor in that case
- fall back to ProcessPoolExecutor otherwise

## Testing
- `python -m py_compile zemosaic_worker.py`

------
https://chatgpt.com/codex/tasks/task_e_685d6dc049ec832f8d4697bfebb85f48