### PR TITLE
Reduce memory usage by memmapping cache loads

### DIFF
--- a/zemosaic_worker.py
+++ b/zemosaic_worker.py
@@ -752,7 +752,10 @@ def create_master_tile(
         # pcb_tile(f"    {func_id_log_base}_{tile_id}_Img{i}: Lecture cache '{os.path.basename(cached_image_file_path)}'", prog=None, lvl="DEBUG_VERY_DETAIL")
         
         try:
-            img_data_adu = np.load(cached_image_file_path) 
+            # Load cached image using memmap to avoid pulling the entire
+            # array into RAM at once. Only accessed pages will be read
+            # into memory on demand.
+            img_data_adu = np.load(cached_image_file_path, mmap_mode='r')
             if not (isinstance(img_data_adu, np.ndarray) and img_data_adu.dtype == np.float32 and img_data_adu.ndim == 3 and img_data_adu.shape[-1] == 3):
                 pcb_tile(f"{func_id_log_base}_warn_invalid_cached_data", prog=None, lvl="WARN", filename=os.path.basename(cached_image_file_path), 
                          shape=img_data_adu.shape if hasattr(img_data_adu, 'shape') else 'N/A', 


### PR DESCRIPTION
## Summary
- load cached images in phase 3 using `np.load(..., mmap_mode='r')`

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile $(git ls-files '*.py')`
- `python zemosaic_worker.py --help`


------
https://chatgpt.com/codex/tasks/task_e_685daf7302cc832fb5ee8cd02fe47c1a