### PR TITLE
Handle ASTAP tmp FITS write errors

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -151,6 +151,7 @@
     "getwcs_warn_header_wcs_read_failed": "GetWCS_Pretreat WARN: Failed to read WCS from FITS header of '{filename}': {error}. Attempting ASTAP.",
     "getwcs_info_astap_solved": "GetWCS_Pretreat: ASTAP successfully solved '{filename}'.",
     "getwcs_warn_astap_failed": "GetWCS_Pretreat WARN: ASTAP did NOT solve '{filename}'.",
+    "getwcs_error_astap_tempfile_write_failed": "GetWCS_Pretreat ERROR: Failed to write temporary FITS for ASTAP for '{filename}': {error}.",
     "getwcs_warn_no_header_wcs_astap_unavailable": "GetWCS_Pretreat WARN: No WCS in header and ASTAP not available/used for '{filename}'.",
     "getwcs_error_final_wcs_invalid": "GetWCS_Pretreat ERROR: Final WCS for '{filename}' is invalid or not celestial.",
     "getwcs_error_set_pixel_shape_final": "GetWCS_Pretreat ERROR: Failed setting final pixel_shape: {error}.",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -176,6 +176,7 @@
     "getwcs_warn_header_wcs_read_failed": "GetWCS_Pretreat AVERT : Échec lecture WCS du header FITS de '{filename}' : {error}. Tentative ASTAP.",
     "getwcs_info_astap_solved": "GetWCS_Pretreat : ASTAP a résolu '{filename}'.",
     "getwcs_warn_astap_failed": "GetWCS_Pretreat AVERT : ASTAP n'a PAS résolu '{filename}'.",
+    "getwcs_error_astap_tempfile_write_failed": "GetWCS_Pretreat ERREUR : Échec d'écriture du FITS temporaire pour ASTAP pour '{filename}' : {error}.",
     "getwcs_warn_no_header_wcs_astap_unavailable": "GetWCS_Pretreat AVERT : Pas de WCS dans header et ASTAP non disponible/utilisé pour '{filename}'.",
     "getwcs_error_final_wcs_invalid": "GetWCS_Pretreat ERREUR : WCS final pour '{filename}' non valide ou non céleste.",
     "getwcs_error_set_pixel_shape_final": "GetWCS_Pretreat ERREUR : Échec de la définition du pixel_shape final : {error}.",


### PR DESCRIPTION
## Summary
- avoid unhandled exception when writing temporary FITS before calling ASTAP
- log an explicit message if the temporary file cannot be written
- add French and English translations for the new error

## Testing
- `python -m py_compile zemosaic_worker.py zemosaic_astrometry.py`


------
https://chatgpt.com/codex/tasks/task_e_685dd05011f4832f91406b512a329062