### PR TITLE
Fix FITS temp file write error

### DIFF
--- a/zemosaic_worker.py
+++ b/zemosaic_worker.py
@@ -569,7 +569,6 @@ def get_wcs_and_pretreat_raw_file(file_path: str, astap_exe_path: str, astap_dat
                 img_data_raw_adu,
                 header=header_orig,
                 overwrite=True,
-                memmap=True,
             )
         except Exception as e_tmp_write:
             _pcb_local(


### PR DESCRIPTION
## Summary
- fix `memmap` argument error when writing temporary ASTAP FITS

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685dd30ccd9c832fbc8565371d0265e2