### PR TITLE
Fix crash when zarr is missing

### DIFF
--- a/zemosaic_worker.py
+++ b/zemosaic_worker.py
@@ -1260,9 +1260,11 @@ def assemble_final_mosaic_reproject_coadd(
     os.makedirs(memmap_dir, exist_ok=True)
 
     if DirectoryStore is None:
-        raise ImportError(
-            "Compatible DirectoryStore implementation not found in zarr."
+        _pcb(
+            "ASM_REPROJ_COADD ERROR: Zarr DirectoryStore unavailable. Install 'zarr' package.",
+            lvl="ERROR",
         )
+        return None, None
     store = LRUStoreCache(DirectoryStore(memmap_dir), max_size=512 * 1024 * 1024)
     root = zarr.open_group(store=store, mode="a")
     if n_channels > 1:


### PR DESCRIPTION
## Summary
- avoid raising ImportError when zarr's DirectoryStore is unavailable
- log a clear error and abort Reproject & Coadd assembly gracefully

## Testing
- `python -m py_compile zemosaic_worker.py`

------
https://chatgpt.com/codex/tasks/task_e_685dd53d4b20832fa52cf52053a5731a