### PR TITLE
Fix Zarr 3 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,9 @@ It was born out of a need from an astrophotography Discord community called the 
 pip install numpy astropy reproject opencv-python photutils scipy psutil
 ```
 The worker originally required `DirectoryStore`, removed in `zarr>=3`.
-ZeMosaic now falls back to `LocalStore`, so both zarr 2.x and 3.x are
-supported (tested on Python 3.11+).
+ZeMosaic now falls back to `LocalStore`, and skips the old
+`LRUStoreCache` wrapper when running against Zarr 3.
+Both Zarr 2.x and 3.x are supported (tested on Python 3.11+).
 
 🧠 Inspired by PixInsight
 ZeMosaic draws strong inspiration from the image integration strategies of PixInsight, developed by Juan Conejero at Pleiades Astrophoto.

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ tk
 psutil
 Photutils
 zarr>=2
+packaging

--- a/zemosaic_worker.py
+++ b/zemosaic_worker.py
@@ -36,13 +36,16 @@ logger.info("Logging pour ZeMosaicWorker initialisé. Logs écrits dans: %s", lo
 # --- Third-Party Library Imports ---
 import numpy as np
 import zarr
+from packaging.version import Version
 
 try:
-    # Zarr >=2.x
     from zarr.storage import LRUStoreCache
-except Exception:  # pragma: no cover - fallback for older Zarr versions or zarr>=3
+    if Version(zarr.__version__).major >= 3:
+        # In zarr>=3 LRUStoreCache was removed. Use a no-op wrapper
+        raise ImportError
+except Exception:  # pragma: no cover - fallback for zarr>=3 or missing cache
     class LRUStoreCache:
-        """Fallback pass-through cache when LRUStoreCache is unavailable."""
+        """Simple pass-through wrapper used when LRUStoreCache is unavailable."""
 
         def __init__(self, store, max_size=None):
             self.store = store


### PR DESCRIPTION
## Summary
- support zarr 3 by disabling `LRUStoreCache` wrapper when it isn't available
- add packaging dependency
- update README about Zarr 3

## Testing
- `python -m py_compile zemosaic_worker.py zemosaic_utils.py zemosaic_astrometry.py zemosaic_align_stack.py run_zemosaic.py zemosaic_gui.py`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_685dd759d550832f8441e853ea418dd5