### PR TITLE
Fix reproject_and_coadd compatibility

### DIFF
--- a/zemosaic_worker.py
+++ b/zemosaic_worker.py
@@ -1307,15 +1307,28 @@ def assemble_final_mosaic_reproject_coadd(
     if assembly_process_workers <= 0:
         assembly_process_workers = None
 
+    # Build kwargs dynamically to remain compatible with older reproject
+    reproj_kwargs = {"match_bg": match_bg}
+    try:
+        import inspect
+        sig = inspect.signature(reproject_and_coadd)
+        if "process_workers" in sig.parameters:
+            reproj_kwargs["process_workers"] = assembly_process_workers
+        if "use_memmap" in sig.parameters:
+            reproj_kwargs["use_memmap"] = use_memmap
+        if "memmap_dir" in sig.parameters:
+            reproj_kwargs["memmap_dir"] = memmap_dir
+        if "cleanup_memmap" in sig.parameters:
+            reproj_kwargs["cleanup_memmap"] = cleanup_memmap
+    except Exception:
+        # If introspection fails just fall back to basic arguments
+        reproj_kwargs = {"match_bg": match_bg}
+
     mosaic_data, coverage = reproject_and_coadd(
         input_data_all_tiles_HWC_processed,
         final_output_wcs.to_header() if hasattr(final_output_wcs, "to_header") else final_output_wcs,
         final_output_shape_hw,
-        match_bg=match_bg,
-        process_workers=assembly_process_workers,
-        use_memmap=use_memmap,
-        memmap_dir=memmap_dir,
-        cleanup_memmap=cleanup_memmap,
+        **reproj_kwargs,
     )
 
     _log_memory_usage(progress_callback, "Fin assemble_final_mosaic_reproject_coadd")


### PR DESCRIPTION
## Summary
- handle older versions of `reproject` that don't support new arguments

## Testing
- `python -m py_compile zemosaic_worker.py`
- `python -m py_compile run_zemosaic.py zemosaic_utils.py zemosaic_gui.py zemosaic_align_stack.py zemosaic_astrometry.py`


------
https://chatgpt.com/codex/tasks/task_e_685deb93ae7c832f8f4e861ac5e08b94