### PR TITLE
Fallback memmap dir to output

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ L’exécutable final se trouvera dans dist/zemosaic.exe.
   "assembly_process_workers": 0
 }
 ```
+(If `coadd_memmap_dir` is empty, ZeMosaic uses the chosen output folder.)
 A final mosaic of 20 000 × 20 000 px in RGB needs ≈ 4.8 GB
 (4 × H × W × float32). Make sure the target disk/SSD has enough space.
 Hot pixel masks detected during preprocessing are also written to the temporary

--- a/locales/en.json
+++ b/locales/en.json
@@ -299,6 +299,7 @@
     "gui_memmap_cleanup": "Delete *.dat when finished",
     "gui_auto_limit_frames": "Auto limit frames per master tile (system stability)",
     "reject_winsor_info_channel_progress": "Winsorized Sigma Clip processing channel {channel}...",
-    "reject_winsor_info_mono_progress": "Winsorized Sigma Clip processing monochrome data..."
+    "reject_winsor_info_mono_progress": "Winsorized Sigma Clip processing monochrome data...",
+    "run_info_memmap_dir_default_output": "Memmap directory not specified. Using output folder '{directory}'."
 
 }

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -295,6 +295,7 @@
     "gui_memmap_cleanup": "Supprimer les *.dat à la fin",
     "gui_auto_limit_frames": "Limiter automatiquement les images par master tile (stabilité système)",
     "reject_winsor_info_channel_progress": "Winsorized Sigma Clip : traitement du canal {channel}...",
-    "reject_winsor_info_mono_progress": "Winsorized Sigma Clip : traitement image monochrome..."
+    "reject_winsor_info_mono_progress": "Winsorized Sigma Clip : traitement image monochrome...",
+    "run_info_memmap_dir_default_output": "Dossier memmap non défini. Utilisation du dossier de sortie '{directory}'."
     
 }

--- a/zemosaic_worker.py
+++ b/zemosaic_worker.py
@@ -1894,12 +1894,15 @@ def run_hierarchical_mosaic(
         log_key_phase5_failed = "run_error_phase5_assembly_failed_incremental"
         log_key_phase5_finished = "run_info_phase5_finished_incremental"
     else: # Méthode Reproject & Coadd
-        if not reproject_coadd_available: 
+        if not reproject_coadd_available:
             pcb("run_error_phase5_reproject_coadd_func_missing", prog=None, lvl="CRITICAL"); return
+        if coadd_use_memmap_config and not coadd_memmap_dir_config:
+            coadd_memmap_dir_config = output_folder
+            pcb("run_info_memmap_dir_default_output", prog=None, lvl="INFO_DETAIL", directory=coadd_memmap_dir_config)
         pcb("run_info_phase5_started_reproject_coadd", prog=base_progress_phase5, lvl="INFO")
         final_mosaic_data_HWC, final_mosaic_coverage_HW = assemble_final_mosaic_reproject_coadd(
-            master_tile_fits_with_wcs_list=valid_master_tiles_for_assembly, 
-            final_output_wcs=final_output_wcs, 
+            master_tile_fits_with_wcs_list=valid_master_tiles_for_assembly,
+            final_output_wcs=final_output_wcs,
             final_output_shape_hw=final_output_shape_hw,
             progress_callback=progress_callback,
             n_channels=3, 


### PR DESCRIPTION
## Summary
- provide default memmap directory
- document automatic memmap directory fallback
- add translation for new log message

## Testing
- `python -m py_compile zemosaic_worker.py run_zemosaic.py`

------
https://chatgpt.com/codex/tasks/task_e_685e51a7ffac832fa6ae2419a7146565