### PR TITLE
Fix NaN issues in stretching and preview

### DIFF
--- a/zemosaic_utils.py
+++ b/zemosaic_utils.py
@@ -624,9 +624,15 @@ def stretch_auto_asifits_like(img_hwc_adu, p_low=0.5, p_high=99.8,
 
     if apply_wb:
         avg_per_chan = np.mean(out, axis=(0, 1))
-        avg_per_chan /= np.max(avg_per_chan) + 1e-8
+        norm = np.max(avg_per_chan)
+        if norm > 0:
+            avg_per_chan /= norm
+        else:
+            avg_per_chan = np.ones_like(avg_per_chan)
         for c in range(3):
-            out[..., c] /= avg_per_chan[c]
+            denom = avg_per_chan[c]
+            if denom > 1e-8:
+                out[..., c] /= denom
 
     return np.clip(out, 0, 1)
 

--- a/zemosaic_worker.py
+++ b/zemosaic_worker.py
@@ -2042,7 +2042,12 @@ def run_hierarchical_mosaic(
                 )
 
                 if m_stretched is not None:
-                    img_u8 = (np.clip(m_stretched.astype(np.float32), 0, 1) * 255).astype(np.uint8)
+                    img_u8 = (
+                        np.nan_to_num(
+                            np.clip(m_stretched.astype(np.float32), 0, 1)
+                        )
+                        * 255
+                    ).astype(np.uint8)
                     png_path = os.path.join(output_folder, f"{output_base_name}_preview.png")
                     try: 
                         import cv2 # Importer cv2 seulement si nécessaire


### PR DESCRIPTION
## Summary
- avoid divide-by-zero in `stretch_percentile_rgb`
- sanitize NaNs before converting stretched preview to uint8

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685e6512c064832f9bff9f0ff0cc3f48