### PR TITLE
Fix incremental reprojection order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
 ## Unreleased
 - Added configurable `winsor_worker_limit` (CLI `--winsor-workers` / `-W` and GUI field)
 - Manual frame cap via `max_raw_per_master_tile` (CLI/GUI/config)
+- Fixed incremental assembly with reproject>=0.11

--- a/zemosaic_worker.py
+++ b/zemosaic_worker.py
@@ -302,7 +302,7 @@ def reproject_tile_to_mosaic(tile_path: str, tile_wcs, mosaic_wcs, mosaic_shape_
         (base_weight, tile_wcs),
         mosaic_wcs,
         shape_out=mosaic_shape_hw,
-        order='nearest',  # suffit, c'est binaire
+        order='nearest-neighbor',  # suffit, c'est binaire
         parallel=False,
     )
 


### PR DESCRIPTION
## Summary
- update incremental mode to use `nearest-neighbor` interpolation
- document the fix in the changelog

## Testing
- `python -m py_compile zemosaic_worker.py`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_685ea2a4d478832f9c29a911d2c4758d