### PR TITLE
Fix incremental crop usage

### DIFF
--- a/zemosaic_worker.py
+++ b/zemosaic_worker.py
@@ -1111,9 +1111,9 @@ def assemble_final_mosaic_incremental(
                     tile_wcs_hdr,
                     output_wcs_hdr,
                     final_output_shape_hw,
-                    True,
-                    apply_crop,
-                    crop_percent,
+                    feather=True,
+                    apply_crop=apply_crop,
+                    crop_percent=crop_percent,
                 )
                 future_map[future] = tile_idx
 


### PR DESCRIPTION
## Summary
- pass cropping parameters by keyword when scheduling tile reproject jobs

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685eae7eb75c832f9990268be8486bea