### PR TITLE
Fix incremental assembly shape handling

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -303,6 +303,7 @@
     "max_raw_per_master_tile_label": "Max raw per master tile",
     "max_raw_per_master_tile_note": "0 = automatic (calculated). Positive value = maximum raw images per master tile.",
     "reject_winsor_info_channel_progress": "Winsorized Sigma Clip processing channel {channel}...",
-    "reject_winsor_info_mono_progress": "Winsorized Sigma Clip processing monochrome data..."
+    "reject_winsor_info_mono_progress": "Winsorized Sigma Clip processing monochrome data...",
 
+    "assemble_error_invalid_final_shape_inc": "Incremental assembly ERROR: invalid final output shape {shape}."
 }

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -299,6 +299,7 @@
     "max_raw_per_master_tile_label": "Brutes max par master-tuile",
     "max_raw_per_master_tile_note": "0 = automatique (calculé). Valeur positive = nombre maximum d'images brutes par master-tuile.",
     "reject_winsor_info_channel_progress": "Winsorized Sigma Clip : traitement du canal {channel}...",
-    "reject_winsor_info_mono_progress": "Winsorized Sigma Clip : traitement image monochrome..."
+    "reject_winsor_info_mono_progress": "Winsorized Sigma Clip : traitement image monochrome...",
     
+    "assemble_error_invalid_final_shape_inc": "ERREUR assemblage incrémental : dimensions finales invalides {shape}."
 }

--- a/zemosaic_worker.py
+++ b/zemosaic_worker.py
@@ -1044,8 +1044,20 @@ def assemble_final_mosaic_incremental(
         pcb_asm("assemble_error_no_tiles_provided_incremental", prog=None, lvl="ERROR")
         return None, None
 
-    # final_output_shape_hw is in (height, width) order
-    h, w = final_output_shape_hw
+    # ``final_output_shape_hw`` MUST be provided in ``(height, width)`` order.
+    if (
+        not isinstance(final_output_shape_hw, (tuple, list))
+        or len(final_output_shape_hw) != 2
+    ):
+        pcb_asm(
+            "assemble_error_invalid_final_shape_inc",
+            prog=None,
+            lvl="ERROR",
+            shape=str(final_output_shape_hw),
+        )
+        return None, None
+
+    h, w = map(int, final_output_shape_hw)
     sum_shape = (h, w, n_channels)
     weight_shape = (h, w)
 


### PR DESCRIPTION
## Summary
- validate `final_output_shape_hw` in incremental assembly
- add new localization messages for invalid shape errors

## Testing
- `python -m py_compile zemosaic_worker.py`
- `python -m json.tool locales/en.json > /dev/null`
- `python -m json.tool locales/fr.json > /dev/null`


------
https://chatgpt.com/codex/tasks/task_e_685eb4527234832fa9a25e5dffbbccc4